### PR TITLE
Transpose Beam Display

### DIFF
--- a/DRX/driftcurve.py
+++ b/DRX/driftcurve.py
@@ -68,7 +68,7 @@ def main(args):
         alt, az = numpy.meshgrid(alt, az)
         pylab.figure(1)
         pylab.title("Beam Response: %s pol. @ %0.2f MHz" % (pol, freq/1e6))
-        pylab.imshow(BeamPattern(az, alt), interpolation='nearest', extent=(0,359, 0,89), origin='lower')
+        pylab.imshow(BeamPattern(az, alt).T, interpolation='nearest', extent=(0,359, 0,89), origin='lower')
         pylab.xlabel("Azimuth [deg]")
         pylab.ylabel("Altitude [deg]")
         pylab.grid(1)


### PR DESCRIPTION
Display of the beam shape on the sky was transposed making the beam appear in the incorrect spot from the plot. This should fix that to match with what is provided by estimateBeam.